### PR TITLE
Include api key when making a call to an API controller

### DIFF
--- a/app/views/spree/admin/return_authorizations/edit.html.erb
+++ b/app/views/spree/admin/return_authorizations/edit.html.erb
@@ -43,6 +43,7 @@
   <br/>
 
   <%= form_tag generate_return_label_api_order_return_authorization_path(@order, @return_authorization), url:  generate_return_label_api_order_return_authorization_path(@order, @return_authorization), method: :post, id: 'return-label-button' do |label_form| %>
+    <%= hidden_field_tag :token, spree_current_user.spree_api_key %>
     <%= label_tag "Shipping Box" %>
     <%= select_tag "spree_shipping_box_id", options_from_collection_for_select(Spree::Shipping::Box.all, :id, :description) %>
     <div class="form-buttons filter-actions actions" data-hook="buttons">


### PR DESCRIPTION
#### What's this PR do?

This PR will include the user's API key when trying to generate a new shipping label, without this `Spree::Api::BaseController` will render the error below.

![screen shot 2015-04-23 at 12 32 48 pm](https://cloud.githubusercontent.com/assets/1505446/7303251/e02d16ca-e9b4-11e4-9a83-5914b375f86d.png)
